### PR TITLE
Remove redundant index

### DIFF
--- a/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
@@ -34,7 +34,6 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
     add_index :good_jobs, [:cron_key, :created_at], name: :index_good_jobs_on_cron_key_and_created_at
     add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
-    add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
   end
 end


### PR DESCRIPTION
Try running active_record_doctor on a project with GoodJob migrations:

```sh
bundle exec rake active_record_doctor
```

You'll see this output:

remove the index index_good_jobs_on_active_job_id from the table
good_jobs - queries should be able to use the following index instead:
index_good_jobs_on_active_job_id_and_created_at

This change removes the single column index on 'active_job_id'

A query that used that index before could instead use the existing
multicolumn index on
['active_job_id', 'created_at'], where ‘active_job_id’ is also the
“leading” column.

The single column index is not a unique index that enforces a unique
constraint.

So the single column appears redundant given the multicolumn index with
the same leading column, which means it could be removed.
